### PR TITLE
Promote public develop to main

### DIFF
--- a/docs/public/desktop/parameter-automation.mdx
+++ b/docs/public/desktop/parameter-automation.mdx
@@ -78,7 +78,7 @@ configuration either way.
 ## TouchDesigner Control Surface
 
 Download the smart TouchDesigner component:
-[baryon_osc.tox](/public/downloads/touchdesigner/baryon_osc.tox)
+[baryon_osc.tox](https://downloads.baryon.live/touchdesigner/baryon_osc.tox)
 
 Use it like this:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,8 +297,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@csstools/color-helpers@6.0.2':
-    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
     engines: {node: '>=20.19.0'}
 
   '@csstools/css-calc@3.2.1':
@@ -308,8 +308,8 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@4.1.8':
-    resolution: {integrity: sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==}
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -1827,8 +1827,8 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
@@ -3185,7 +3185,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.8(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -3242,16 +3242,16 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@csstools/color-helpers@6.0.2': {}
+  '@csstools/color-helpers@6.1.0': {}
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-color-parser@4.1.8(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/color-helpers': 6.0.2
+      '@csstools/color-helpers': 6.1.0
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
@@ -4583,7 +4583,7 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -5855,7 +5855,7 @@ snapshots:
       '@vitest/spy': 4.1.9
       '@vitest/utils': 4.1.9
       es-module-lexer: 2.1.0
-      expect-type: 1.3.0
+      expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -297,6 +297,30 @@ if (scriptExists("scripts/sync-public.sh")) {
   }
 }
 
+const parameterAutomationPath = path.join(
+  rootDir,
+  "docs/public/desktop/parameter-automation.mdx",
+);
+if (fs.existsSync(parameterAutomationPath)) {
+  const parameterAutomation = fs.readFileSync(parameterAutomationPath, "utf8");
+  const touchDesignerArtifactPath =
+    "docs/public/downloads/touchdesigner/baryon_osc.tox";
+  if (!fs.existsSync(path.join(rootDir, touchDesignerArtifactPath))) {
+    errors.push(
+      `${touchDesignerArtifactPath}: missing TouchDesigner control surface artifact`,
+    );
+  }
+  if (
+    !parameterAutomation.includes(
+      "https://downloads.baryon.live/touchdesigner/baryon_osc.tox",
+    )
+  ) {
+    errors.push(
+      "docs/public/desktop/parameter-automation.mdx: TouchDesigner download must use downloads.baryon.live",
+    );
+  }
+}
+
 const polyformLicense = "LicenseRef-PolyForm-Strict-1.0";
 for (const relPath of findWorkspaceManifestPaths()) {
   const packageJson = JSON.parse(


### PR DESCRIPTION
## Summary

- Promotes public `develop` (`5724eaf64aa451fd6001841b0093bfd92257b183`) into public `main` (`ca6fc93bfca521e05e6bf6217e33e005aa9812b8`).
- Carries the R2-backed TouchDesigner `.tox` download fix from private `develop` commit `9a53f6043d8c056ebd27043913e0aecb66ca178f` through public sync PR #66.
- Stops the hosted docs from linking users to the Mintlify-served `/public/downloads/...` asset path that returns 404 for `.tox` files.

## What Changed

- `docs/public/desktop/parameter-automation.mdx`
  - Updates the TouchDesigner OSC component download link to `https://downloads.baryon.live/touchdesigner/baryon_osc.tox`.
- `scripts/check-docs.mjs`
  - Adds a docs guard requiring the source `.tox` artifact to exist in the repo projection.
  - Adds a docs guard requiring the public docs link to use the canonical `downloads.baryon.live` R2-backed URL.
- `pnpm-lock.yaml`
  - Refreshes the public projection lockfile from the private-to-public sync.

## Branch State

- Public `main`: `ca6fc93bfca521e05e6bf6217e33e005aa9812b8`
- Public `develop`: `5724eaf64aa451fd6001841b0093bfd92257b183`
- GitHub compare reports `develop` as 2 commits ahead and 8 commits behind by merge history.
- Effective file delta: 3 files changed, 37 insertions, 13 deletions.
- Ahead commits:
  - `c42a267c9` `sync(core): export public projection`
  - `5724eaf64` `Merge pull request #66 from BaryonOfficial/sync/private-develop`

## Validation

- Public sync PR #66 merged successfully: https://github.com/BaryonOfficial/Baryon/pull/66
- Private CI `Verify` passed on the source private commit `9a53f6043d8c056ebd27043913e0aecb66ca178f`.
- Public sync workflow completed successfully for the public projection.
- Local full verification passed before sync: `pnpm verify` recorded cache for tree `2e27d7a3aa79a2f85dd65f62be757f6021d514ca`.
- Targeted docs validation passed:
  - `node scripts/check-docs.mjs`
  - `node --test scripts/check-docs.test.mjs scripts/public-export.test.mjs`
- R2 download surface was verified directly:
  - `https://downloads.baryon.live/touchdesigner/baryon_osc.tox` returned HTTP 200.
  - Object size is 5,822 bytes.
  - SHA256 matches `be0ca4f230517942c4b8bba9550854eb49b692b5499669b95a7c4c1c2ba47fdb`.
  - Sidecar checksum is available at `https://downloads.baryon.live/touchdesigner/baryon_osc.tox.sha256`.

## Merge Notes

- This is the public release promotion for the docs download fix now present on public `develop`.
- Wait for this PRs checks/review to complete, then merge using the normal public repo settings.