### PR TITLE
Promote public develop to main: remove app tracking scripts

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,35 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script>
-      window._iub = window._iub || [];
-      window._iub.csConfiguration = {
-        siteId: 4486931,
-        cookiePolicyId: 51069743,
-        lang: "en",
-        storage: { useSiteId: true },
-      };
-    </script>
-    <script src="https://cs.iubenda.com/autoblocking/4486931.js"></script>
-    <script src="https://cdn.iubenda.com/cs/gpp/stub.js"></script>
-    <script
-      src="https://cdn.iubenda.com/cs/iubenda_cs.js"
-      charset="UTF-8"
-      async
-    ></script>
-    <!-- Google tag (gtag.js) -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-YMD7QT46R7"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-      gtag("config", "G-YMD7QT46R7");
-    </script>
     <meta charset="UTF-8" />
     <link
       rel="icon"


### PR DESCRIPTION
## Summary

Promotes the latest public `develop` projection to `main` after public sync PR #77.

This release removes Google Analytics and Iubenda from the Baryon web application while preserving the app's existing Vercel Web Analytics and Speed Insights instrumentation.

## Why

The web application is an immersive, full-canvas product surface. Iubenda's persistent privacy widget occupied application chrome and overlapped the `FILE / SYSTEM` control area. Google Analytics was initialized only for general page tracking, duplicating the traffic visibility already provided by Vercel Analytics.

The change removes the consent UI together with the non-essential tracker that required it. It does not hide consent controls while leaving Google Analytics active.

## Exact changes

### Removed from `apps/web/index.html`

- the `window._iub` configuration
- Iubenda autoblocking
- the Iubenda GPP stub and consent client
- the Google Tag Manager / `gtag.js` loader
- the `dataLayer` initialization
- the Google Analytics `gtag("config", "G-YMD7QT46R7")` call

### Intentionally preserved

- `@vercel/analytics` at the web application's React root
- `@vercel/speed-insights` at the web application's React root
- the marketing site's CookieYes consent implementation
- the marketing site's Google Analytics implementation
- all web-app rendering, audio, AR Lab, controls, and playback behavior

## Expected runtime behavior

After deployment and a fresh page load:

- `app.baryon.live` should no longer display the Iubenda banner or floating privacy widget
- the web app should make no requests to Iubenda or `googletagmanager.com`
- Vercel Analytics and Speed Insights should continue reporting through their existing app-root integrations
- `baryon.live` marketing analytics and consent behavior should remain unchanged

## Review surface

The public `main...develop` compare contains:

- **1 modified file**
- **29 deletions**
- **0 additions**

The only content change is `apps/web/index.html`.

## Verification

The exact private source tree exported by #77 passed:

- `pnpm --filter @baryon/web build`
- full `pnpm verify`
- the repository's post-verify cache recording
- `pnpm verify:cache:check`

Static searches also confirmed that the generated web build contains no Iubenda or Google Analytics references.

## Source provenance

- Private source branch: `develop`
- Private source head: `1f70b2cc2de9`
- Public sync PR: #77
- Public `develop` head: `3c992945b722`
- Public `main` base: `6934d6d333f8`

The public branches are expected to appear diverged because prior `develop → main` releases are represented by merge commits on `main`. The effective release delta remains the one-file tracker removal described above.

## Merge strategy

Use a **regular merge commit**. Do not squash or rebase: public projection history uses `private-sha:` trailers, and regular merges preserve the branch ancestry used to track what has already landed publicly.
