### PR TITLE
release: promote public develop to main

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -13,6 +13,7 @@ import {
   useFullscreenUiPreference,
 } from "@baryon/app-shell";
 import ArLabLaunchButton from "./ar-lab/ArLabLaunchButton.jsx";
+import { AR_LAB_ACCESS_ENABLED } from "./ar-lab/arLabRoute.js";
 
 // Sits clear of the demo note: safe area + the note's 0.85rem offset, its
 // ~1.6rem box, and a gap.
@@ -46,7 +47,9 @@ export default function App() {
             }
             liveInputPanel={mobileDemoMode ? null : { showAction: true }}
             controlsBrandAccessory={
-              mobileDemoMode ? null : <ArLabLaunchButton />
+              mobileDemoMode || !AR_LAB_ACCESS_ENABLED ? null : (
+                <ArLabLaunchButton />
+              )
             }
             controlsDockVisible={!mobileDemoMode}
             cameraControlsVisible

--- a/apps/web/src/ar-lab/arLabRoute.js
+++ b/apps/web/src/ar-lab/arLabRoute.js
@@ -1,5 +1,9 @@
 export const AR_LAB_PATH = "/ar-lab";
 
+// Product availability gate. Keep the AR implementation in the tree while it
+// is not reliable enough to expose in the web app.
+export const AR_LAB_ACCESS_ENABLED = false;
+
 export const AR_LAB_MODES = Object.freeze({
   // Milestone 0 hardware proof: WebGPU + XR host with one inert sphere and
   // no Baryon pipeline, providers, audio, controls, hands, or recording.
@@ -19,6 +23,14 @@ export function isArLabPath(pathname) {
 
   const normalized = pathname.replace(/\/+$/, "") || "/";
   return normalized === AR_LAB_PATH;
+}
+
+/**
+ * @param {string | null | undefined} pathname
+ * @returns {boolean}
+ */
+export function shouldOpenArLab(pathname) {
+  return AR_LAB_ACCESS_ENABLED && isArLabPath(pathname);
 }
 
 /**

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -7,7 +7,7 @@ import App from "./App.jsx";
 // Hidden WebXR AR lab. Branches before AudioProvider/ControlsProvider so the
 // lab owns its own provider composition.
 import ArLabApp from "./ar-lab/ArLabAppLazy.jsx";
-import { isArLabPath } from "./ar-lab/arLabRoute.js";
+import { shouldOpenArLab } from "./ar-lab/arLabRoute.js";
 import "./index.css";
 
 if (
@@ -26,7 +26,7 @@ if (!rootElement) {
 
 ReactDOM.createRoot(rootElement).render(
   <AppErrorBoundary surfaceName="Baryon Web">
-    {isArLabPath(window.location.pathname) ? (
+    {shouldOpenArLab(window.location.pathname) ? (
       <Suspense fallback={null}>
         <ArLabApp />
       </Suspense>

--- a/apps/web/tests/ar-lab.smoke.spec.js
+++ b/apps/web/tests/ar-lab.smoke.spec.js
@@ -1,7 +1,10 @@
 import { Buffer } from "node:buffer";
 import { expect, test } from "@playwright/test";
+import { AR_LAB_ACCESS_ENABLED } from "../src/ar-lab/arLabRoute.js";
 
-test.describe("Baryon AR lab smoke", () => {
+test.describe("Baryon AR implementation smoke", () => {
+  test.skip(!AR_LAB_ACCESS_ENABLED, "AR Lab access is disabled");
+
   test("loads /ar-lab without crashing and previews when only AR is missing", async ({
     page,
     browserName,
@@ -265,6 +268,36 @@ test.describe("Baryon AR lab smoke", () => {
     await expect(page.getByTestId("live-input-status-panel")).toBeVisible();
     await expect(
       page.getByTestId("ar-lab-live-input-device-select"),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Baryon AR access", () => {
+  test.skip(AR_LAB_ACCESS_ENABLED, "AR Lab access is enabled");
+
+  test("does not expose the AR launch control", async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== "chromium", "WebGPU smoke is chromium-only");
+
+    await page.goto("/");
+    await expect(
+      page.getByRole("button", { name: "Toggle settings" }),
+    ).toBeVisible();
+    await expect(page.getByTestId("ar-lab-launch-button")).toHaveCount(0);
+  });
+
+  test("does not open AR from the direct route", async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(browserName !== "chromium", "WebGPU smoke is chromium-only");
+
+    await page.goto("/ar-lab");
+    await expect(page.getByTestId("ar-lab-root")).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Toggle settings" }),
     ).toBeVisible();
   });
 });

--- a/apps/web/tests/unit/arLabRoute.test.js
+++ b/apps/web/tests/unit/arLabRoute.test.js
@@ -1,10 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  AR_LAB_ACCESS_ENABLED,
   AR_LAB_MODES,
   isArLabPath,
   resolveArLabMode,
+  shouldOpenArLab,
 } from "../../src/ar-lab/arLabRoute.js";
+
+test("keeps AR Lab access disabled", () => {
+  assert.equal(AR_LAB_ACCESS_ENABLED, false);
+  assert.equal(shouldOpenArLab("/ar-lab"), false);
+  assert.equal(shouldOpenArLab("/ar-lab/"), false);
+});
 
 test("matches /ar-lab with and without a trailing slash", () => {
   assert.equal(isArLabPath("/ar-lab"), true);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3195,8 +3195,8 @@ packages:
   ts-proto-descriptors@2.1.0:
     resolution: {integrity: sha512-S5EZYEQ6L9KLFfjSRpZWDIXDV/W7tAj8uW7pLsihIxyr62EAVSiKuVPwE8iWnr849Bqa53enex1jhDUcpgquzA==}
 
-  ts-proto@2.12.0:
-    resolution: {integrity: sha512-ezMxg57ZiK/ZTW14U7y38+qyWHJr8cn8ELKuppANER666YnUteuNFO/mM1qI+9/wAHoTAfRadnIwtVdp1xw0jQ==}
+  ts-proto@2.12.1:
+    resolution: {integrity: sha512-IEFvmib22yVlXbagL/UXcfliCPilgqXs3J0/ajDhUslfezMRhhhZvwgc63W0ZrKxCj+8jMHxvrN6G13A5UGFVg==}
     hasBin: true
 
   tsconfig-paths-webpack-plugin@4.2.0:
@@ -3903,7 +3903,7 @@ snapshots:
     dependencies:
       iwer: 2.3.0
       three: 0.165.0
-      ts-proto: 2.12.0
+      ts-proto: 2.12.1
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6338,7 +6338,7 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 2.14.0
 
-  ts-proto@2.12.0:
+  ts-proto@2.12.1:
     dependencies:
       '@bufbuild/protobuf': 2.14.0
       case-anything: 2.1.13


### PR DESCRIPTION
## What does this PR do?

Promotes the reviewed public `develop` projection to `main`.

This is the public release merge following [sync PR #81](https://github.com/BaryonOfficial/Baryon/pull/81).

## Changes

- Removes the AR Lab launch control from the web app while the experience is unavailable.
- Prevents direct `/ar-lab` visits from mounting the AR application; the normal web app loads instead.
- Keeps the AR implementation and its focused coverage in the repository for later re-enablement.
- Makes the AR availability flag the single owner for both UI and route access.
- Updates the projected public lockfile.

## Branch topology

- Base: `main` at `31c57f5dc6c8`
- Head: `develop` at `8a0755911c95`
- Release content: generated public projection `89a476950c5a`, merged through #81
- GitHub reports `develop` behind `main` by prior `develop → main` merge commits. Those are historical release merges; this PR carries the two commits currently ahead of `main`.

## Testing and checks

- [x] Public `verify` passed on `develop`.
- [x] Public sync PR #81 passed `verify`, CLA Assistant, GitGuardian, and Socket checks.
- [x] Web unit suite passed: 107 tests.
- [x] Web typecheck, lint, and production build passed.
- [x] Production Playwright access checks passed: the launch control is absent and `/ar-lab` does not mount AR.
- [x] Dormant AR implementation smoke coverage remains in place and is skipped while access is disabled.

## Reviewer focus

1. Confirm the AR launch control is absent from the normal web app.
2. Confirm `/ar-lab` falls through to the normal app instead of mounting the unavailable experience.
3. Confirm the retained AR implementation remains isolated behind the canonical availability flag.

## Merge result

After required checks and review, merging this PR makes the unavailable-AR access gate authoritative on public `main`.
